### PR TITLE
Add ordering and query tag to seat status query

### DIFF
--- a/BookingService.Infrastructure/Repositories/EventSeatStatusRepository.cs
+++ b/BookingService.Infrastructure/Repositories/EventSeatStatusRepository.cs
@@ -57,6 +57,8 @@ namespace BookingService.Infrastructure.Repositories
                 // Use LINQ with EF Core for better readability and maintainability
                 return await _context.EventSeatStatuses
                     .Where(ess => ess.EventId == eventId && seatIds.Contains(ess.SeatId))
+                    .OrderBy(ess => ess.SeatId)
+                    .TagWith("FOR UPDATE")
                     .ToListAsync();
             }
             catch (Exception ex)


### PR DESCRIPTION
The EventSeatStatusRepository query now orders results by SeatId and includes a 'FOR UPDATE' tag for improved query traceability and potential locking semantics.